### PR TITLE
refactor Tile, Deck, and deckSpec to add land features to tiles

### DIFF
--- a/server/deck.js
+++ b/server/deck.js
@@ -1,20 +1,20 @@
 var Tile = require('./tile');
 // var spec = require('./deckSpec');
 
-
 // this is what a deck should look like
-  // [ {id: a0, orientation: 0}, {id: a1, orientation: 0}, ... ] 
+  // [ {id: u, orientation: 0, features: {...}, x: undefined, y: undefined}, 
+    // {id: c, orientation: 0, features: {...}, x: undefined, y: undefined}, ... ] 
 
 // takes a `spec` argument
-// the spec is an object, it contains letter keys (i.e. a, b, c)
-  // and its values are integers representing the number of 
-  // each of that card in the deck. 
-// if that is confusing just look at the `cards` object below and it might make sense...
+// the spec is an object, it contains a letter keys which represent the type of card
+  // a quantity property which is the number of cards for each type
+  // and a features property, which describes the features on each direction of the tile
+// if that is confusing, require('./deckSpec') and make a deck. 
 var Deck = function(spec){
   this.deck = [];
   for (var key in spec){
-    for (var i = 0; i < spec[key]; i++) {
-      this.deck.push(new Tile ( key + i ));
+    for (var i = 0; i < spec[key].quantity; i++) {
+      this.deck.push(new Tile ( key, spec[key].features ));
     }
   }
   this.startTile = this.deck.pop();
@@ -35,9 +35,6 @@ Deck.prototype.shuffle = function() {
     this.deck[currentIndex] = this.deck[randomIndex];
     this.deck[randomIndex] = temporaryValue;
   }
-
-  // if group approves _ inclusion, replace all that with
-  // _.shuffle(this.deck);
 };
 
 // removes and returns the card from the top of the deck

--- a/server/deckSpec.js
+++ b/server/deckSpec.js
@@ -4,31 +4,226 @@
 // the int in the array is part of the id, and represents how many
   // of a given card there is
 
+
+// deck spec v3, now has land features
+
 var deckSpec = {
-  d: 4,
-  a: 2,
-  b: 5,
-  c: 1,
-  e: 5,
-  f: 2,
-  g: 1,
-  h: 3,
-  i: 2,
-  j: 3,
-  k: 3,
-  l: 3,
-  m: 2,
-  n: 3,
-  o: 2,
-  p: 3,
-  q: 1,
-  r: 3,
-  s: 2,
-  t: 1,
-  u: 8,
-  v: 9,
-  w: 4,
-  x: 1
+  d: {
+    quantity: 4,
+    features: {
+      n: 'road',
+      s: 'road',
+      e: 'city',
+      w: 'grass'
+    }
+  },
+  a: {
+    quantity: 2,
+    features: {
+      n: 'grass',
+      s: 'road',
+      e: 'grass',
+      w: 'grass'
+    }
+  },
+  b: {
+    quantity: 5,
+    features: {
+      n: 'grass',
+      s: 'grass',
+      e: 'grass',
+      w: 'grass'
+    }
+  },
+  c: {
+    quantity: 1,
+    features: {
+      n: 'city',
+      s: 'city',
+      e: 'city',
+      w: 'city'
+    }
+  },
+  e: {
+    quantity: 5,
+    features: {
+      n: 'city',
+      s: 'grass',
+      e: 'grass',
+      w: 'grass'
+    }
+  },
+  f: {
+    quantity: 2,
+    features: {
+      n: 'grass',
+      s: 'grass',
+      e: 'city',
+      w: 'city'
+    }
+  },
+  g: {
+    quantity: 1,
+    features: {
+      n: 'city',
+      s: 'city',
+      e: 'grass',
+      w: 'grass'
+    }
+  },
+  h: {
+    quantity: 3,
+    features: {
+      n: 'grass',
+      s: 'grass',
+      e: 'city',
+      w: 'city'
+    }
+  },
+  i: {
+    quantity: 2,
+    features: {
+      n: 'grass',
+      s: 'city',
+      e: 'city',
+      w: 'grass'
+    }
+  },
+  j: {
+    quantity: 3,
+    features: {
+      n: 'city',
+      s: 'road',
+      e: 'road',
+      w: 'grass'
+    }
+  },
+  k: {
+    quantity: 3,
+    features: {
+      n: 'road',
+      s: 'grass',
+      e: 'city',
+      w: 'road'
+    }
+  },
+  l: {
+    quantity: 3,
+    features: {
+      n: 'road',
+      s: 'road',
+      e: 'city',
+      w: 'road'
+    }
+  },
+  m: {
+    quantity: 2,
+    features: {
+      n: 'city',
+      s: 'grass',
+      e: 'grass',
+      w: 'city'
+    }
+  },
+  n: {
+    quantity: 3,
+    features: {
+      n: 'city',
+      s: 'grass',
+      e: 'grass',
+      w: 'city'
+    }
+  },
+  o: {
+    quantity: 2,
+    features: {
+      n: 'city',
+      s: 'road',
+      e: 'city',
+      w: 'road'
+    }
+  },
+  p: {
+    quantity: 3,
+    features: {
+      n: 'city',
+      s: 'road',
+      e: 'city',
+      w: 'road'
+    }
+  },
+  q: {
+    quantity: 1,
+    features: {
+      n: 'city',
+      s: 'grass',
+      e: 'city',
+      w: 'city'
+    }
+  },
+  r: {
+    quantity: 3,
+    features: {
+      n: 'city',
+      s: 'grass',
+      e: 'city',
+      w: 'city'
+    }
+  },
+  s: {
+    quantity: 2,
+    features: {
+      n: 'city',
+      s: 'road',
+      e: 'city',
+      w: 'city' 
+    }
+  },
+  t: {
+    quantity: 1,
+    features: {
+      n: 'city',
+      s: 'road',
+      e: 'city',
+      w: 'city'
+    }
+  },
+  u: {
+    quantity: 8,
+    features: {
+      n: 'road',
+      s: 'road',
+      e: 'grass',
+      w: 'grass'
+    }
+  },
+  v: {
+    quantity: 9,
+    features: {
+      n: 'grass',
+      s: 'road',
+      e: 'grass',
+      w: 'road'
+    }
+  },
+  w: {
+    quantity: 4,
+    features: {
+      n: 'grass',
+      s: 'road',
+      e: 'road',
+      w: 'road'
+    }
+  },
+  x: {
+    quantity: 1,
+    features: {
+      n: 'road',
+      s: 'road',
+      e: 'road',
+      w: 'road'
+    }
+  }
 };
 
 module.exports = deckSpec;

--- a/server/tile.js
+++ b/server/tile.js
@@ -1,19 +1,62 @@
 /* this is what a tile should look like going to and coming from client
     {
-      id: v9,          // (A thru X) + num
+      id: a,          // (A thru X) + num
       orientation: 1,  // 0 - 3
       x: 13,           // 0 - boardSize
       y: 2,            // 0 - boardSize
-      meeple: {}       // ref to actual meeple object see ./meeples.js
+      meeple: ** to do, meeple location stuff**
+      feature = {
+        n: 'grass',
+        s: 'road',
+        e: 'grass',
+        w: 'grass'
+      }
     } 
 */
 
-var Tile = function(id, x, y, meeple){
+var Tile = function(id, features, x, y, meeple){
   this.id = id;
-  this.orientation = 0;
   this.x = x;
   this.y = y;
+  this.orientation = 0;
+  this.features = features;
   this.meeple = meeple;
 };
 
+// use this on client side and remove from here.
+// will make tile validation easier if features
+// rotate with tile.
+Tile.prototype.rotateRight = function() {
+  this.orientation = (this.orientation + 1) % 4;
+
+  var temp = {};
+  for (var key in this.features){
+    temp[key] = this.features[key];
+  }
+
+  this.features.n = temp.w;
+  this.features.e = temp.n;
+  this.features.s = temp.e;
+  this.features.w = temp.s;
+};
+
 module.exports = Tile;
+
+// Below here is a simple demo, uncomment to see rotation in action
+// rotation should be a client side function, but it's here until
+// someone on front end needs it
+
+// var feat = {
+//       n: 'grass',
+//       s: 'road',
+//       e: 'grass',
+//       w: 'grass'
+//     };
+
+// var tile = new Tile('a', feat);
+
+// console.log(tile);
+// tile.rotateRight();
+// console.log(tile);
+// tile.rotateRight();
+// console.log(tile);


### PR DESCRIPTION
This PR is to add land features to tiles, which are pretty straight forward from what i can tell.  

if you break the tile down into 3 pieces to each side, it would look something like `'grass, road, grass'` at `n`(orth) on a `d` tile. It turns out there's only 3 patterns for any given side (`n,s,e,w`) of a tile: `'grass, road, grass'`,  `'city, city, city'`, `'grass, grass, grass'` -- so they can be simplified to `'road'`, `'city'`, `'grass'`.

So an `a` tile's features will be like:  
```javascript
tile.features: { 
  n: 'grass',
  s: 'road',
  e: 'grass',
  w: 'grass'
}
```
i've made a sample rotation function that actually belongs on the client side. the features rotate with the tile, so if `'road'` is at `s`, when you `tile.rotateRight()`, `'road'` is now at `w` after rotation... etc. validating tile placement should be easier this way.