### PR TITLE
fixing bower dependency issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,5 +20,8 @@
     "angular-route": "~1.4.1",
     "bootstrap-sass": "~3.3.5",
     "angular-notify": "~2.5.0"
+  },
+  "resolutions": {
+    "angular": "~1.4.1"
   }
 }


### PR DESCRIPTION
Angular notify seems to want 1.3, changed my bower.json file to clear this up and make sure it installs 1.4.1 so we can deploy without issue.